### PR TITLE
Update kling.py

### DIFF
--- a/kling/kling.py
+++ b/kling/kling.py
@@ -476,7 +476,7 @@ class ImageGen(BaseGen):
         if response_body.get("data").get("status") == 7:
             message = response_body.get("data").get("message")
             raise Exception(f"Request failed message {message}")
-        request_id = response_body.get("data", {}).get("task", {}).get("id")
+        request_id = (response_body.get("data", {}).get("task") or {}).get("id")
         if not request_id:
             raise Exception("Could not get request ID")
         start_wait = time.time()


### PR DESCRIPTION
In the design of the Kling API, in many error scenarios, the `task` key is not missing but present and equal to `None`. In this case, None will be unpacked instead of being assigned the default value `{}`. This commit fixes this issue.