### PR TITLE
Fix: UserAgent fallback

### DIFF
--- a/kling/kling.py
+++ b/kling/kling.py
@@ -13,7 +13,7 @@ from rich import print
 import threading
 
 browser_version = "edge101"
-ua = UserAgent(browsers=["edge"])
+ua = UserAgent(browsers=["Edge"])
 base_url = "https://klingai.kuaishou.com/"
 base_url_not_cn = "https://klingai.com/"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests
 rich
-fake-useragent
+fake-useragent>=2.0.3

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     url="https://github.com/yihong0618/klingCreator",
     install_requires=[
         "requests",
-        "fake-useragent",
+        "fake-useragent>=2.0.3",
         "rich",
     ],
     packages=find_packages(exclude=["tests", "tests.*"]),


### PR DESCRIPTION
After starting, always prints warning `Error occurred during getting browser(s): random, but was suppressed with fallback.` from `fake-useragent`. This issue is due to new version supported browsers list. To fix it i correct browser name and add version specification.

<img width="1150" height="107" alt="image" src="https://github.com/user-attachments/assets/cd1ab833-0d30-490f-8106-25a97cd7518a" />
